### PR TITLE
Fixed text and tokens fields for some utterances

### DIFF
--- a/data/sim-M/test.json
+++ b/data/sim-M/test.json
@@ -8322,7 +8322,9 @@
             "like",
             "one",
             "of",
-            " those options ?"
+            "those",
+            "options",
+            "?"
           ]
         },
         "user_acts": [

--- a/data/sim-M/train.json
+++ b/data/sim-M/train.json
@@ -92204,7 +92204,7 @@
               "start": 7
             }
           ],
-          "text": "your tickets for the accountant tonight at shoreline theater have been purchased .",
+          "text": "your tickets for the accountant tonight at shoreline at 7:15 theater have been purchased .",
           "tokens": [
             "your",
             "tickets",
@@ -101758,7 +101758,7 @@
               "start": 16
             },
             {
-              "exclusive_end": 29,
+              "exclusive_end": 19,
               "slot": "theatre_name",
               "start": 18
             }

--- a/data/sim-R/dev.json
+++ b/data/sim-R/dev.json
@@ -83950,7 +83950,7 @@
               "start": 5
             }
           ],
-          "text": "i found a restaurant named pepper .",
+          "text": "i found a restaurant named pepper in mountain view .",
           "tokens": [
             "i",
             "found",


### PR DESCRIPTION
During preprocessing of this dataset I found a couple of inconsistencies between the `text` and `tokens` fields. This PR fixes those.